### PR TITLE
Fix: Update Dockerfile to correctly use Bun and its lockfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 # Install dependencies
 COPY package*.json ./
 # If you have a bun.lockb file, you should also copy it:
-# COPY bun.lockb ./
+COPY bun.lock ./
 RUN bun install --production
 
 # Copy source code


### PR DESCRIPTION
Ensures `bun.lock` is copied for reproducible builds. I verified that the application builds and attempts to run with Bun, exiting as expected due to missing API keys (per your instructions).